### PR TITLE
Nsm desktop key

### DIFF
--- a/packaging/shuriken.desktop
+++ b/packaging/shuriken.desktop
@@ -12,5 +12,3 @@ X-NSM-Capable=true
 X-NSM-Exec=shuriken
 Type=Application
 Categories=AudioVideo;Audio;AudioVideoEditing;
-
-

--- a/packaging/shuriken.desktop
+++ b/packaging/shuriken.desktop
@@ -8,5 +8,9 @@ Comment[fr]=Trancheur de rythme
 Exec=shuriken %F
 Icon=shuriken
 Terminal=false
+X-NSM-Capable=true
+X-NSM-Exec=shuriken
 Type=Application
 Categories=AudioVideo;Audio;AudioVideoEditing;
+
+


### PR DESCRIPTION
Add NSM related keys for tools to find NSM clients

X-NSM-Capable should be ideally become false if the application is build without NSM support.
X-NSM-Exec, is the exec name of the application when used in NSM. It can't contain a path (not /usr/bin/ for example) or command line arguments like %f.